### PR TITLE
Make plugin work with Radicale 3.x

### DIFF
--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -19,6 +19,7 @@ import imaplib
 import ssl
 
 from radicale.auth import BaseAuth
+from radicale.config import _convert_to_bool
 
 
 class Auth(BaseAuth):
@@ -34,12 +35,20 @@ class Auth(BaseAuth):
 
     def login(self, user, password):
         # Parse configuration options
-        host = ''
-        if self.configuration.has_option('auth', 'imap_host'):
+        try:
             host = self.configuration.get('auth', 'imap_host')
-        secure = True
-        if self.configuration.has_option('auth', 'imap_secure'):
-            secure = self.configuration.getboolean('auth', 'imap_secure')
+        except KeyError:
+            host = ''
+
+        try:
+            # Radicale only does bool conversion based on config schema
+            # and there seems to be no way for plugins to add items to
+            # the schema. To ensure consistent boolean parsing, this
+            # uses an internal function.
+            secure = _convert_to_bool(self.configuration.get('auth', 'imap_secure'))
+        except KeyError:
+            secure = True
+
         try:
             if ':' in host:
                 address, port = host.rsplit(':', maxsplit=1)

--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -20,6 +20,7 @@ import ssl
 
 from radicale.auth import BaseAuth
 from radicale.config import _convert_to_bool
+from radicale.log import logger
 
 
 class Auth(BaseAuth):
@@ -81,7 +82,7 @@ class Auth(BaseAuth):
         try:
             connection.login(user, password)
         except imaplib.IMAP4.error as e:
-            self.logger.debug(
+            logger.debug(
                 'IMAP authentication failed: %s', e, exc_info=True)
             return ""
 

--- a/radicale_imap/__init__.py
+++ b/radicale_imap/__init__.py
@@ -32,7 +32,7 @@ class Auth(BaseAuth):
     imap_secure = True
     """
 
-    def is_authenticated(self, user, password):
+    def login(self, user, password):
         # Parse configuration options
         host = ''
         if self.configuration.has_option('auth', 'imap_host'):
@@ -74,7 +74,7 @@ class Auth(BaseAuth):
         except imaplib.IMAP4.error as e:
             self.logger.debug(
                 'IMAP authentication failed: %s', e, exc_info=True)
-            return False
+            return ""
 
         connection.logout()
-        return True
+        return user


### PR DESCRIPTION
In Radicale 3.0, the plugin API was changed in an incompatible way. This PR updates the plugin to work with 3.x (tested with 3.0.6), but breaks compatibility with 2.x (I initially tried keeping it compatible with both, but it doesn't seem worth the effort). I split the changes in different commits by subject for easy review.